### PR TITLE
fix packet drop issue, at least for small number of channels

### DIFF
--- a/synapse_cereplex/electrical_broadband.py
+++ b/synapse_cereplex/electrical_broadband.py
@@ -1,5 +1,6 @@
 from enum import Enum
 import threading
+import time
 
 from cerebus import cbpy
 
@@ -103,6 +104,9 @@ class ElectricalBroadband(BaseNode):
 
                 if self.emit_data:
                     self.emit_data((DataType.kBroadband, t0, data))
+
+                time.sleep(0.001)
+
             except Exception as e:
                 self.logger.warn(f"failed to read data: {e}")
 


### PR DESCRIPTION
this one line of code + plugging my weird laptop into ethernet (2 other laptops we tested work just fine on wifi, so does the blackrock cart itself) made packet / sample loss go from >85% to <1% over 30 seconds of recording, up to ~12 channels at a time. 

I think replacing parts of python code with C tomorrow will allow us to send many more channels at once, but wanted to commit this one simple fix anyway.